### PR TITLE
Add --enable-pie to build options

### DIFF
--- a/mozconfig
+++ b/mozconfig
@@ -18,6 +18,7 @@ ac_add_options --enable-optimize
 ac_add_options --enable-safe-browsing
 ac_add_options --enable-strip
 ac_add_options --enable-url-classifier
+ac_add_options --enable-pie
 
 # Dependencies we took directly from the runtime
 ac_add_options --enable-system-ffi


### PR DESCRIPTION
This will build thunderbird as Position independent Executable. It's common hardening option used by many distros, i.e. https://src.fedoraproject.org/rpms/thunderbird/blob/master/f/thunderbird-mozconfig#_22