### PR TITLE
Use bundled nss

### DIFF
--- a/mozconfig
+++ b/mozconfig
@@ -21,8 +21,9 @@ ac_add_options --with-system-zlib
 #ac_add_options --with-system-libvpx
 ac_add_options --with-system-bz2
 ac_add_options --with-system-icu
-ac_add_options --with-system-nss
-ac_add_options --with-system-nspr
+# https://bugzilla.mozilla.org/show_bug.cgi?id=1465613
+#ac_add_options --with-system-nss
+#ac_add_options --with-system-nspr
 ac_add_options --with-system-png
 # https://github.com/flathub/org.mozilla.Thunderbird/pull/61#issue-275142159
 #ac_add_options --enable-system-sqlite


### PR DESCRIPTION
Otherwise TB can't recognize new certficate attributes.

https://github.com/p11-glue/p11-kit/commit/1def8077a2bc1fc2a6bd3685a9d94a9a51f40e23
https://src.fedoraproject.org/fork/ueno/rpms/ca-certificates/c/6aec97d9bdcbb92ef912a60b86060f4bc6481b1a
https://git.archlinux.org/svntogit/packages.git/commit/trunk?h=packages/nss&id=49ab909853249c416be0918ebe40a8effc938ff1