### PR TITLE
Remove old bug workaround, fixed in upstream

### DIFF
--- a/mozconfig
+++ b/mozconfig
@@ -46,11 +46,6 @@ ac_add_options --disable-updater
 ac_add_options --disable-gconf
 ac_add_options --disable-startup-notification
 
-# Fix potential crashes (remove for TB 68)
-# https://bugs.archlinux.org/task/60779
-# https://bugzilla.mozilla.org/show_bug.cgi?id=1423822
-ac_add_options --disable-elf-hack
-
 # Needed to enable breakpad in application.ini
 export MOZILLA_OFFICIAL=1
 


### PR DESCRIPTION
New version 3.36 of `gcr` switches to the meson build system, and has a new set of config-opts. The `--enable-valgrind` flag was removed, so `vala` is now a needed dependency. I think I got the build flags for `gcr` right, but the available flags are:

`introspection`
Build GObject Introspection (GIR) files
`gtk`
Build code that uses GTK+
`gtk_doc`
Build the reference documentation (requires gtk-doc)

All are set to true by default, and I set `gtk_doc` to false. I was unsure about `introspection`, but I believe in 3.34 it was also set to true by default, and no flags disabling it were passed, so I left it to default to true.

Since now two package dependencies (`libnotify` and `vala`) are provided by the upstream `org.gnome.Platform` runtime, it makes sense to switch for a lower maintenance burden.

Also removed an outdated bug workaround [(#1423822)](https://bugzilla.mozilla.org/show_bug.cgi?id=1423822), as it has been fixed in upstream Thunderbird.