### PR TITLE
Fix Exec line in .desktop file

### DIFF
--- a/org.mozilla.Thunderbird.desktop
+++ b/org.mozilla.Thunderbird.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Encoding=UTF-8
-Exec=thunderbird %u
+Exec=thunderbird %f
 Icon=thunderbird
 Terminal=false
 Type=Application


### PR DESCRIPTION
According to the desktop entry spec (https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s07.html) %u is used for URL parameters and %f for file names. Thunderbird does not seem to be able to handle URL-like paramaters (e.g. file:///path/to/file) but only filename parameters (e.g. /path/to/file). Therefore %f should be used. This allows tools to adjust the parameter passed accordingly.