### PR TITLE
Improve update script

### DIFF
--- a/thunderbird-sources.json.template
+++ b/thunderbird-sources.json.template
@@ -1,8 +1,0 @@
-[
-    $LANGPACKS
-    {
-        "type": "archive",
-        "url": "https://archive.mozilla.org/pub/thunderbird/releases/$VERSION/source/thunderbird-$VERSION.source.tar.xz",
-        "sha256": "$CHECKSUM"
-    }
-]

--- a/update-thunderbird-version.sh
+++ b/update-thunderbird-version.sh
@@ -2,7 +2,7 @@
 set -eo pipefail
 
 if [ -z "$1" ]; then
-  echo "Usage: $0 URL"
+  echo "Usage: $0 VERSION"
   echo ""
   echo "Example: $0 68.1.1"
   exit 1
@@ -11,36 +11,43 @@ fi
 VERSION="$1"
 PACKAGE=thunderbird
 PLATFORM=linux-x86_64
-SOURCE_URL="https://archive.mozilla.org/pub/$PACKAGE/releases/$VERSION"
-MANIFEST_NAME="$PACKAGE-sources"
-MANIFEST_FILE_TEMPLATE="$MANIFEST_NAME.json.template"
-MANIFEST_FILE="$MANIFEST_NAME.json"
+BASE_URL="https://archive.mozilla.org/pub/$PACKAGE/releases/$VERSION"
+SOURCES_FILE="$PACKAGE-sources.json"
 
-mkdir -p langpacks
-cd langpacks || exit
-wget -nc "$SOURCE_URL/SHA256SUMS"
-CHECKSUM="$(grep "source/$PACKAGE-$VERSION.source.tar.xz" SHA256SUMS | cut -d\  -f1)"
-wget -nc -nd -np --recursive --level=0 "$SOURCE_URL/$PLATFORM/xpi/"
-for lang in *.xpi
-do
-LOCALE="$(basename -s .xpi "$lang")"
-LOCALE_CHECKSUM="$(grep "$PLATFORM/xpi/$lang" SHA256SUMS | cut -d\  -f1)"
-LANGPACKS="$LANGPACKS
+# write new sources file
+echo '[' > "$SOURCES_FILE"
+
+# read files from SHA256SUMS file
+while read -r line; do
+  checksum="${line%%  *}"
+  path="${line#*  }"
+
+  # store source archive entry for later, because it should be the last element
+  # in the json array
+  if [[ $path =~ ^source/ ]]; then
+    source_archive='    {
+        "type": "archive",
+        "url": "'"$BASE_URL"'/'"$path"'",
+        "sha256": "'"$checksum"'"
+    }'
+
+  # add locale to sources file
+  else
+    # strip directories and .xpi extension
+    locale="${path##*/}"
+    locale="${locale%.*}"
+
+    cat >> "$SOURCES_FILE" <<EOT
     {
-        \"type\": \"file\",
-        \"url\": \"$SOURCE_URL/$PLATFORM/xpi/$lang\",
-        \"sha256\": \"$LOCALE_CHECKSUM\",
-        \"dest\": \"langpacks/\",
-        \"dest-filename\": \"langpack-$LOCALE@$PACKAGE.mozilla.org.xpi\"
-    },"
-done
-cd - || exit
+        "type": "file",
+        "url": "$BASE_URL/$path",
+        "sha256": "$checksum",
+        "dest": "langpacks/",
+        "dest-filename": "langpack-$locale@$PACKAGE.mozilla.org.xpi"
+    },
+EOT
+  fi
+done < <(curl -Ss "$BASE_URL/SHA256SUMS" | grep "^\S\+  \(source\|$PLATFORM/xpi\)/")
 
-export VERSION
-export CHECKSUM
-export LANGPACKS
-
-< "$MANIFEST_FILE_TEMPLATE" envsubst > "$MANIFEST_FILE"
-
-# Cleanup downloaded langpacks
-rm -rf langpacks
+# add source archive entry to sources file
+echo -e "$source_archive\n]" >> "$SOURCES_FILE"


### PR DESCRIPTION
Instead of downloading all locale files and iterating over them, the
locale file names are read from the sha256 checksum file. In addition,
the source entry is now generated by the bash script, so that the
external template file is not necessary anymore.