### PR TITLE
Detect dark theme for GTK based DEs like elementary OS

### DIFF
--- a/org.mozilla.Thunderbird.json
+++ b/org.mozilla.Thunderbird.json
@@ -38,6 +38,8 @@
         /* GPG support */
         "--filesystem=~/.gnupg",
         "--filesystem=xdg-run/gnupg:ro"
+        /* Needed for perfers-color-scheme */
+        "--system-talk-name=org.freedesktop.Accounts"
     ],
     "cleanup": [
         "/include",

--- a/org.mozilla.Thunderbird.json
+++ b/org.mozilla.Thunderbird.json
@@ -37,7 +37,7 @@
         "--require-version=0.10.3",
         /* GPG support */
         "--filesystem=~/.gnupg",
-        "--filesystem=xdg-run/gnupg:ro"
+        "--filesystem=xdg-run/gnupg:ro",
         /* Needed for perfers-color-scheme */
         "--system-talk-name=org.freedesktop.Accounts"
     ],


### PR DESCRIPTION
I'd like to propose the addition of the `--system-talk-name=org.freedesktop.Accounts` argument to enable the detection of the Dark/Light variation on GTK based distros that follow the FreeDesktop specifications.