### PR TITLE
Remove unneded env setting

### DIFF
--- a/org.mozilla.Thunderbird.json
+++ b/org.mozilla.Thunderbird.json
@@ -41,7 +41,6 @@
         /* Kerberos support */
         "--filesystem=/run/.heim_org.h5l.kcm-socket",
         /* Printing support */
-        "--env=GTK_PATH=/app/lib/gtkmodules",
         "--socket=cups"
     ],
     "cleanup": [


### PR DESCRIPTION
This doesn't have purpose after move to 22.08 runtime