### PR TITLE
Drop Notifications bus permission

### DIFF
--- a/org.mozilla.Thunderbird.json
+++ b/org.mozilla.Thunderbird.json
@@ -29,8 +29,6 @@
         "--talk-name=org.a11y.Bus",
         /* Needed for detecting running instance on wayland */
         "--own-name=org.mozilla.thunderbird_default.*",
-        /* Make notifications work */
-        "--talk-name=org.freedesktop.Notifications",
         /* Smartcard access - Requires flatpak >= 1.3.2 */
         "--socket=pcsc",
         /* Older versions will fail with above permission */


### PR DESCRIPTION
Since libnotify 0.8+ notifications work without permission:

https://gitlab.gnome.org/GNOME/libnotify/-/commit/f3eb807464e06eb68b2901e553a21e31620aba53